### PR TITLE
Managing certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains files to bootstrap XNAT deployment. The build creates f
 2. Configurations: The default configuration is sufficient to run the deployment. The following files can be modified if you want to change the default configuration
 
     - **docker-compose.yml**: How the different containers are deployed.
+    - **docker-compose.override.yml**: Overrides/extends default settings in docker-compose.yml(e.g: setting up SSL certificates)
     - **postgres/XNAT.sql**: Database configuration. Mainly used to customize the database user or password. See [Configuring PostgreSQL for XNAT](https://wiki.xnat.org/documentation/getting-started-with-xnat-1-7/installing-xnat-1-7/configuring-postgresql-for-xnat).
     - **tomcat/Dockerfile**: Builds the tomcat image, into which the XNAT war will be deployed.
     - **tomcat/setenv.sh**: Tomcat's launch arguments, set through the `JAVA_OPTS` environment variable.
@@ -41,7 +42,7 @@ wget --quiet --no-cookies https://bintray.com/nrgxnat/applications/download_file
 
 ```
 $ cd xnat-docker-compose
-$ docker-compose up -d
+$ docker-compose -f docker-compose.yml up -d
 ```
 
 Note that at this point, if you go to `localhost/xnat` you won't see a working web application. It takes upwards of a minute
@@ -76,6 +77,26 @@ Your XNAT will soon be available at http://localhost/xnat.
 
 ## Installing plugins and pipeline
 Run add-plugins.sh script
+
+## Setting up SSL certificates for NginX
+Bring down instance if already running
+```
+docker-compose down
+```
+Change working directory to `xnat-docker-compose/nginx/`
+
+Create a directory named as `certs`
+```
+mkdir certs
+```
+Copy SSL certificate file(with root and intermediate certificates as one file) to this directory and name it as `cert.crt` and copy key file to this directory and name it as `key.key`
+
+
+Start the system
+```
+docker-compose up -d 
+
+```
 
 ## Troubleshooting
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,5 +2,6 @@ version: '3'
 services:
     xnat-nginx:
        volumes:
-          - ./nginx/certs:/etc/nginx/
+          - ./nginx/certs/cert.crt:/etc/nginx/certs/cert.crt
+          - ./nginx/certs/key.key:/etc/nginx/certs/key.key
           - ./nginx/nginx-ssl.conf:/etc/nginx/nginx.conf

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+    xnat-nginx:
+       volumes:
+          - ./nginx/certs:/etc/nginx/
+          - ./nginx/nginx-ssl.conf:/etc/nginx/nginx.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services: 
     xnat-web:
        build: ./tomcat

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -1,4 +1,43 @@
-
+#user www-data;
+worker_processes auto;
+events {
+  worker_connections 1024;
+  # multi_accept on;
+}
+http {
+  ##
+  # Basic Settings
+  ##
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  # server_tokens off;
+  # server_names_hash_bucket_size 64;
+  # server_name_in_redirect off;
+  #include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+  ##
+  # SSL Settings
+  ##
+  #ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+  #ssl_prefer_server_ciphers on;
+  ##
+  # Logging Settings
+  ##
+  access_log /var/log/nginx/access.log;
+  error_log /var/log/nginx/error.log;
+  ##
+  # Gzip Settings
+  ##
+  gzip on;
+  gzip_disable "msie6";
+  ##
+  # Virtual Host Configs
+  ##
+  #include /etc/nginx/conf.d/*.conf;
+  #include /etc/nginx/sites-enabled/*;
 # Redirect http requests to https
 server {
   listen 80 default_server;
@@ -41,4 +80,5 @@ server {
 
     access_log /var/log/nginx/customsite.access_ssl.log;
     error_log /var/log/nginx/customsite.error_ssl.log;
+}
 }

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -17,7 +17,7 @@ server {
 
 
     ssl_certificate /etc/nginx/certs/cert.crt;
-    ssl_certificate_key /etc/nginx/certs/private/key.key;
+    ssl_certificate_key /etc/nginx/certs/key.key;
 
     root /var/lib/tomcat7/webapps/ROOT;
 

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -1,0 +1,44 @@
+
+# Redirect http requests to https
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name change.me;
+  return 301 https://$server_name$request_uri;
+}
+
+server {
+# see https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/
+# to see why we hardwire the IP address
+    listen 443 ssl;  
+    server_name change.me;
+    ssl on;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+
+    ssl_certificate /etc/nginx/certs/cert.crt;
+    ssl_certificate_key /etc/nginx/certs/private/key.key;
+
+    root /var/lib/tomcat7/webapps/ROOT;
+
+    location / {
+
+      proxy_pass http://xnat-web:8080;
+      proxy_redirect http://xnat-web:8080 $scheme://localhost;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Server $host;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto  $scheme;
+      proxy_connect_timeout 150;
+      proxy_send_timeout 100;
+      proxy_read_timeout 100;
+      proxy_buffers 4 32k;
+      client_max_body_size 0;
+      client_body_buffer_size 128k;
+    }
+
+    access_log /var/log/nginx/customsite.access_ssl.log;
+    error_log /var/log/nginx/customsite.error_ssl.log;
+}


### PR DESCRIPTION
@tclose a command line switch will not be possible , but with the current approach a user can bring the instance w/o specifying SSL certs by running `docker-compose -f docker-compose.yml up -d`. This will bring up the instance w/o SSL cert. 
And to bring up the instance with SSL certs you can run the command `docker-compose up -d` which will pick up SSL certs from `nginx/certs/` directory.[https://github.com/mbi-image/xnat-docker-compose/tree/managing_certs#setting-up-ssl-certificates-for-nginx](url)