### PR TITLE
Logs on volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ View a particular log, if you don't want to use docker-compose.
 ```
 docker exec -it $NAME cat /opt/tomcat/logs/catalina.2017-10-24.log
 ```
-Logs are wriiten on docker host for tomcat,nginx and postgres under follow directories
+Logs are written on docker host for tomcat,nginx and postgres under following directories:
 
 	Postgres : xnat-docker-compose/postgres-data/logs
     

--- a/README.md
+++ b/README.md
@@ -142,7 +142,14 @@ View a particular log, if you don't want to use docker-compose.
 ```
 docker exec -it $NAME cat /opt/tomcat/logs/catalina.2017-10-24.log
 ```
+Logs are wriiten on docker host for tomcat,nginx and postgres under follow directories
 
+	Postgres : xnat-docker-compose/postgres-data/logs
+    
+	Nginx : xnat-docker-compose/logs/nginx
+        
+	Tomcat : xnat-docker-compose/logs/tomcat
+	
 ### Controlling Instances
 
 #### Stop Instances

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
          - ./webapps:/opt/tomcat/webapps
          - ./plugins:/data/xnat/home/plugins
          - /var/run/docker.sock:/var/run/docker.sock
+         - ./logs/tomcat:/opt/tomcat/logs
        expose:
         - "8080"
        links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,10 +25,12 @@ services:
        ports:
         - "80:80"
         - "443:443"
+       volumes:
+          - ./logs/nginx:/var/log/nginx
        expose: 
-        - "80"
+          - "80"
        links:
-         - xnat-web
+          - xnat-web
 
     prometheus:
        image: prom/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,12 @@ services:
         - xnat-db    
     xnat-db:
        build: ./postgres
+       command: postgres -c logging_collector=on -c log_destination=stderr -c log_directory=/logs
        expose:
          - "5432"
        volumes:
          - ./postgres-data:/var/lib/postgresql/data
+         - ./postgres-data/logs:/logs
     xnat-nginx:
        build: ./nginx
        ports:

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,3 +1,7 @@
 FROM postgres:9.4-alpine
 
 COPY XNAT.sql /docker-entrypoint-initdb.d/
+
+#for logging to a volume
+RUN mkdir /logs
+RUN chown postgres:postgres /logs


### PR DESCRIPTION
With this change the logs for tomcat, nginx and postgres are written on docker host and log directories are mounted as volumes.