### PR TITLE
Fix backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,9 @@ Although this typically won't be neccessary and you are on your own from then on
 
 
 ## Setup postgres backup
-Postgres backups are scheduled to run at 0300 hrs everyday but can be configures by modifying `SETUP_CRON` environment under `xnat-backup` service.
+Postgres backups are scheduled to run at 0300 hrs everyday but can be configures by modifying crontab file environment under backup directory.
 ```
-xnat-backup:
-     ...
-     environment:
-       SETUP_CRON: "0 3 * * *"
+0 3 * * *  /backup
 ```
 The `xnat-backup` service is configured to create nighly backups under `backups` directory, but can be configured by overriding this value in `docker-compose.override.yml` file.
 ```

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -5,17 +5,13 @@ MAINTAINER Manish Kumar <rishimanish123@gmail.com>
 #install postgres client
 RUN apk update \
  && apk add --no-cache --virtual .build-deps \
- dcron postgresql-client
+ postgresql-client
 
 # disable default crontab
+COPY backup.sh /backup
+RUN chmod +x /backup
 
-COPY crontab /etc/crontab
+COPY crontab /var/spool/cron/crontabs/root
 
-# add the backup scripts into root/home
-ADD backup.sh /root/backup.sh
-RUN chmod +x /root/backup.sh
-ADD backup_init.sh /root/backup_init.sh
-RUN chmod +x /root/backup_init.sh
-RUN mkdir -p /etc/cron.d/
+ENTRYPOINT ["crond", "-f", "-l", "2"]
 
-CMD ["/root/backup_init.sh"]

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 BACKUP_DATE="$(date +%Y-%m-%d_%H:%M)"
 BACKUP_FILE="/backups/"$BACKUP_DATE"_dump.tar.gz"
 DB_FILE="/backups/db.sql"
@@ -5,7 +6,6 @@ DB_FILE="/backups/db.sql"
 # start backup
 
 pg_dump -h xnat-db -U xnat -d xnat -Fc > $DB_FILE
-
 # compress and Copy backup to storage
 
 tar -czf $BACKUP_FILE $DB_FILE

--- a/backup/backup_init.sh
+++ b/backup/backup_init.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-# create backup-cron file...
-echo "$SETUP_CRON root /root/backup.sh > /proc/1/fd/1 2>/proc/1/fd/2" > /etc/cron.d/backup-cron
-chmod 0644 /etc/cron.d/backup-cron
-
-
-# Run cron.....
-crond -f

--- a/backup/crontab
+++ b/backup/crontab
@@ -4,9 +4,7 @@
 # and files in /etc/cron.d. These files also have username fields,
 # that none of the other crontabs do.
 
-SHELL=/bin/sh
-PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-
+0 3 * * *  /backup
 # disable all default crons
 # m h dom mon dow user	command
 #17 *	* * *	root    cd / && run-parts --report /etc/cron.hourly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,8 +46,6 @@ services:
       - xnat-db
     links:
       - xnat-db
-    environment:
-      SETUP_CRON: "0 3 * * *"
     volumes:
       - ./backups:/backups
   xnat-nginx:


### PR DESCRIPTION
This PR aims to fix issue related to backup.

The alpine base image used for running crontab was not able to run CRON jobs when crontab file was modified during container startup.

Current approach is to copy the crontab file while creating the backup container. This means user will have to modify this file before running ``docker-compose up -d `` command